### PR TITLE
added explicit instruction for variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import scipy.stats as st
 np.random.seed(0) #set a random seed for reproducibility
 ```
 
-Next, read in the dataset.  A dataset of 10,000 numbers is stored in `non_normal_dataset.csv`. Use pandas to read the data into a series.
+Next, read in the dataset.  A dataset of 10,000 numbers is stored in `non_normal_dataset.csv`. Use pandas to read the data into a series called `data`.
 
 **_Hint:_** Any of the `read_` methods in pandas will store 1-dimensional in a Series instead of a DataFrame if passed the optimal parameter `squeeze=True`.
 

--- a/index.ipynb
+++ b/index.ipynb
@@ -1,1 +1,294 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# Central Limit Theorem - Lab\n", "\n", "## Introduction\n", "\n", "In this lab, we'll learn how to use the Central Limit Theorem to work with non-normally distributed datasets as if they were normally distributed.  \n", "\n", "## Objectives\n", "You will be able to:\n", "* Use built-in methods to detect non-normal datasets\n", "* Create a sampling distribution of sample means to demonstrate the central limit theorem"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Let's get started!\n", "\n", "First, import the required libraries:"]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["import pandas as pd\n", "import numpy as np\n", "import matplotlib.pyplot as plt\n", "%matplotlib inline\n", "import seaborn as sns\n", "import scipy.stats as st\n", "np.random.seed(0) #set a random seed for reproducibility"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Next, read in the dataset.  A dataset of 10,000 numbers is stored in `non_normal_dataset.csv`. Use pandas to read the data into a series.\n", "\n", "**_Hint:_** Any of the `read_` methods in pandas will store 1-dimensional in a Series instead of a DataFrame if passed the optimal parameter `squeeze=True`."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Your code here"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Detecting Non-Normal Datasets\n", "\n", "Before we can make use of the normal distribution, we need to first confirm that our data is normally distributed.  If it is not, then we'll need to use the Central Limit Theorem to create a sample distribution of sample means that will be normally distributed.  \n", "\n", "There are two main ways to check if a sample follows the normal distribution or not.  The easiest is to simply plot the data and visually check if the data follows a normal curve or not.  \n", "\n", "In the cell below, use `seaborn`'s `distplot` method to visualize a histogram of the distribution overlaid with the probability density curve.  "]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Your code here"]}, {"cell_type": "markdown", "metadata": {}, "source": ["As expected, this dataset is not normally distributed.  \n", "\n", "For a more formal way to check if a dataset is normally distributed or not, we can make use of a statistical test.  There are many different statistical tests that can be used to check for normality, but we'll keep it simple and just make use of the `normaltest()` function from `scipy.stats`, which we imported as `st` --see the [documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.normaltest.html) if you have questions about how to use this method. \n", "\n", "In the cell below, use `normaltest()` to check if the dataset is normally distributed.  "]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Your code here"]}, {"cell_type": "markdown", "metadata": {}, "source": ["The output may seem a bit hard to interpret since we haven't covered hypothesis testing and p-values in further detail yet.  However, the function tests the hypothesis that the distribution passed into the function differs from the normal distribution. The null hypothesis would then be that the data *is* normally distributed. We typically reject the null hypothesis if the p-value is less than 0.05. For now, that's all you need to remember--this will make more sense once you work with p-values more which you'll do subsequently.  \n", "\n", "Since our dataset is non-normal, that means we'll need to use the **_Central Limit Theorem._**"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Sampling With Replacement\n", "\n", "In order to create a Sample Distribution of Sample Means, we need to first write a function that can sample *with* replacement.  \n", "\n", "In the cell below, write a function that takes in an array of numbers `data` and a sample size `n` and returns an array that is a random sample of `data`, of size `n`."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["def get_sample(data, n):\n", "    pass\n", "\n", "test_sample = get_sample(data, 30)\n", "print(test_sample[:5]) \n", "# [56, 12, 73, 24, 8] (This will change if you run it multiple times)"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Generating a Sample Mean\n", "\n", "Next, we'll write another helper function that takes in a sample and returns the mean of that sample.  "]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["def get_sample_mean(sample):\n", "    pass\n", "\n", "test_sample2 = get_sample(data, 30)\n", "test_sample2_mean = get_sample_mean(test_sample2)\n", "print(test_sample2_mean) \n", "# 45.3 (This will also change if you run it multiple times)"]}, {"cell_type": "markdown", "metadata": {}, "source": ["### Creating a Sample Distribution of Sample Means\n", "\n", "Now that we have helper functions to help us sample with replacement and calculate sample means, we just need to bring it all together and write a function that creates a sample distribution of sample means!\n", "\n", "In the cell below, write a function that takes in 3 arguments: the dataset, the size of the distribution to create, and the size of each individual sample. The function should return a sample distribution of sample means of the given size.  "]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["def create_sample_distribution(data, dist_size=100, n=30):\n", "    pass\n", "\n", "test_sample_dist = create_sample_distribution(data)\n", "print(test_sample_dist[:5]) "]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Visualizing the Sample Distribution as it Becomes Normal\n", "\n", "The sample distribution of sample means isn't guaranteed to be normal after it hits a magic size.  Instead, the distribution begins to approximate a normal distribution as it gets larger and larger.  Generally, 30 is accepted as the sample size where the Central Limit Theorem begins to kick in--however, there are no magic numbers when it comes to probability. On average, and only on average, a sample distribution of sample means where the individual sample sizes were 29 would only be slightly less normal, while one with sample sizes of 31 would likely only be slightly more normal.  \n", "\n", "Let's create some sample distributions of different sizes and watch the Central Limit Theorem kick in. As the sample size increases, you'll see the distributions begin to approximate a normal distribution more closely.  \n", "\n", "In the cell below, create a sample distribution from `data` of `dist_size` 10, with a sample size `n` of 3. Then, visualize this sample distribution with `distplot`."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Your code here"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Now, let's increase the `dist_size` to 30, and `n` to 10.  Create another visualization to compare how it changes as size increases.  "]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Your code here"]}, {"cell_type": "markdown", "metadata": {}, "source": ["The data is already looking much more 'normal' than the first sample distribution, and much more 'normal' that the raw non-normal distribution we're sampling from. \n", "\n", "In the cell below, create another sample distribution of `data` with `dist_size` 1000 and `n` of 30.  Visualize it to confirm the normality of this new distribution. "]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Your code here"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Great! As you can see, the dataset _approximates_ a normal distribution. It isn't pretty, but it's generally normal enough that we can use it to answer statistical questions using $z$-scores and p-values.  \n", "\n", "Another handy feature of the Central Limit Theorem is that the mean and standard deviation of the sample distribution should also approximate the population mean and standard deviation from the original non-normal dataset!  Although it's outside the scope of this lab, we could also use the same sampling methods seen here to approximate other parameters from any non-normal distribution, such as the median or mode!"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Summary\n", "\n", "In this lab, we learned to apply the central limit theorem in practice. We learned how to determine if a dataset is normally distributed or not. From there, we used a function to sample with replacement and generate sample means. Afterwards, we created a normal distribution of sample means in order to answer questions about non-normally distributed datasets.  "]}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.7.3"}, "toc": {"base_numbering": 1, "nav_menu": {}, "number_sections": true, "sideBar": true, "skip_h1_title": false, "title_cell": "Table of Contents", "title_sidebar": "Contents", "toc_cell": false, "toc_position": {}, "toc_section_display": true, "toc_window_display": false}}, "nbformat": 4, "nbformat_minor": 2}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Central Limit Theorem - Lab\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "In this lab, we'll learn how to use the Central Limit Theorem to work with non-normally distributed datasets as if they were normally distributed.  \n",
+    "\n",
+    "## Objectives\n",
+    "You will be able to:\n",
+    "* Use built-in methods to detect non-normal datasets\n",
+    "* Create a sampling distribution of sample means to demonstrate the central limit theorem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Let's get started!\n",
+    "\n",
+    "First, import the required libraries:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "import seaborn as sns\n",
+    "import scipy.stats as st\n",
+    "np.random.seed(0) #set a random seed for reproducibility"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, read in the dataset.  A dataset of 10,000 numbers is stored in `non_normal_dataset.csv`. Use pandas to read the data into a series called `data`.\n",
+    "\n",
+    "**_Hint:_** Any of the `read_` methods in pandas will store 1-dimensional in a Series instead of a DataFrame if passed the optimal parameter `squeeze=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Detecting Non-Normal Datasets\n",
+    "\n",
+    "Before we can make use of the normal distribution, we need to first confirm that our data is normally distributed.  If it is not, then we'll need to use the Central Limit Theorem to create a sample distribution of sample means that will be normally distributed.  \n",
+    "\n",
+    "There are two main ways to check if a sample follows the normal distribution or not.  The easiest is to simply plot the data and visually check if the data follows a normal curve or not.  \n",
+    "\n",
+    "In the cell below, use `seaborn`'s `distplot` method to visualize a histogram of the distribution overlaid with the probability density curve.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As expected, this dataset is not normally distributed.  \n",
+    "\n",
+    "For a more formal way to check if a dataset is normally distributed or not, we can make use of a statistical test.  There are many different statistical tests that can be used to check for normality, but we'll keep it simple and just make use of the `normaltest()` function from `scipy.stats`, which we imported as `st` --see the [documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.normaltest.html) if you have questions about how to use this method. \n",
+    "\n",
+    "In the cell below, use `normaltest()` to check if the dataset is normally distributed.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output may seem a bit hard to interpret since we haven't covered hypothesis testing and p-values in further detail yet.  However, the function tests the hypothesis that the distribution passed into the function differs from the normal distribution. The null hypothesis would then be that the data *is* normally distributed. We typically reject the null hypothesis if the p-value is less than 0.05. For now, that's all you need to remember--this will make more sense once you work with p-values more which you'll do subsequently.  \n",
+    "\n",
+    "Since our dataset is non-normal, that means we'll need to use the **_Central Limit Theorem._**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sampling With Replacement\n",
+    "\n",
+    "In order to create a Sample Distribution of Sample Means, we need to first write a function that can sample *with* replacement.  \n",
+    "\n",
+    "In the cell below, write a function that takes in an array of numbers `data` and a sample size `n` and returns an array that is a random sample of `data`, of size `n`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_sample(data, n):\n",
+    "    pass\n",
+    "\n",
+    "test_sample = get_sample(data, 30)\n",
+    "print(test_sample[:5]) \n",
+    "# [56, 12, 73, 24, 8] (This will change if you run it multiple times)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generating a Sample Mean\n",
+    "\n",
+    "Next, we'll write another helper function that takes in a sample and returns the mean of that sample.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_sample_mean(sample):\n",
+    "    pass\n",
+    "\n",
+    "test_sample2 = get_sample(data, 30)\n",
+    "test_sample2_mean = get_sample_mean(test_sample2)\n",
+    "print(test_sample2_mean) \n",
+    "# 45.3 (This will also change if you run it multiple times)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating a Sample Distribution of Sample Means\n",
+    "\n",
+    "Now that we have helper functions to help us sample with replacement and calculate sample means, we just need to bring it all together and write a function that creates a sample distribution of sample means!\n",
+    "\n",
+    "In the cell below, write a function that takes in 3 arguments: the dataset, the size of the distribution to create, and the size of each individual sample. The function should return a sample distribution of sample means of the given size.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_sample_distribution(data, dist_size=100, n=30):\n",
+    "    pass\n",
+    "\n",
+    "test_sample_dist = create_sample_distribution(data)\n",
+    "print(test_sample_dist[:5]) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualizing the Sample Distribution as it Becomes Normal\n",
+    "\n",
+    "The sample distribution of sample means isn't guaranteed to be normal after it hits a magic size.  Instead, the distribution begins to approximate a normal distribution as it gets larger and larger.  Generally, 30 is accepted as the sample size where the Central Limit Theorem begins to kick in--however, there are no magic numbers when it comes to probability. On average, and only on average, a sample distribution of sample means where the individual sample sizes were 29 would only be slightly less normal, while one with sample sizes of 31 would likely only be slightly more normal.  \n",
+    "\n",
+    "Let's create some sample distributions of different sizes and watch the Central Limit Theorem kick in. As the sample size increases, you'll see the distributions begin to approximate a normal distribution more closely.  \n",
+    "\n",
+    "In the cell below, create a sample distribution from `data` of `dist_size` 10, with a sample size `n` of 3. Then, visualize this sample distribution with `distplot`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's increase the `dist_size` to 30, and `n` to 10.  Create another visualization to compare how it changes as size increases.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The data is already looking much more 'normal' than the first sample distribution, and much more 'normal' that the raw non-normal distribution we're sampling from. \n",
+    "\n",
+    "In the cell below, create another sample distribution of `data` with `dist_size` 1000 and `n` of 30.  Visualize it to confirm the normality of this new distribution. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great! As you can see, the dataset _approximates_ a normal distribution. It isn't pretty, but it's generally normal enough that we can use it to answer statistical questions using $z$-scores and p-values.  \n",
+    "\n",
+    "Another handy feature of the Central Limit Theorem is that the mean and standard deviation of the sample distribution should also approximate the population mean and standard deviation from the original non-normal dataset!  Although it's outside the scope of this lab, we could also use the same sampling methods seen here to approximate other parameters from any non-normal distribution, such as the median or mode!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this lab, we learned to apply the central limit theorem in practice. We learned how to determine if a dataset is normally distributed or not. From there, we used a function to sample with replacement and generate sample means. Afterwards, we created a normal distribution of sample means in order to answer questions about non-normally distributed datasets.  "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
The instructions under the "Let's get started!" section include loading the data in `non_normal_dataset.csv` into a pandas series but do not specify a name for the variable to be used. However, later code cells operate under the assumption that the variable is called `data`. To prevent errors and the need for students to either go back and change their original variable name or update each of the pre-populated code cells with their custom variable name, this PR adds specific instructions to call the variable `data`.